### PR TITLE
refactor(formik-apollo): `getValidationErrors` function

### DIFF
--- a/packages/react-native-baseline-inputs/test/index.test.ts
+++ b/packages/react-native-baseline-inputs/test/index.test.ts
@@ -10,6 +10,7 @@ it("exports all inputs", () => {
     "DatePicker",
     "TimePicker",
     "DateTimePicker",
-    "Switch"
+    "Switch",
+    "StaticInput"
   ]);
 });


### PR DESCRIPTION
### Why
https://github.com/apollographql/apollo-link/issues/1116

### How
- replace uses of `e instanceof GraphQLError` with simple field checking